### PR TITLE
don't depend on the existence of the `module` global

### DIFF
--- a/canvas-dpi-scaler.js
+++ b/canvas-dpi-scaler.js
@@ -2,7 +2,8 @@
 //
 // Based on: http://www.html5rocks.com/en/tutorials/canvas/hidpi/
 
-//
+(function() {
+
 var scaleFn = function(canvas, context, customWidth, customHeight) {
   if(!canvas || !context) { throw new Error('Must pass in `canvas` and `context`.'); }
 
@@ -31,6 +32,6 @@ var scaleFn = function(canvas, context, customWidth, customHeight) {
   return ratio;
 };
 
-// expose functionality
-if(typeof window !== 'undefined') { window.canvasDpiScaler = scaleFn; }
-module.exports = scaleFn;
+this.canvasDpiScaler = scaleFn;
+
+}).call(this);


### PR DESCRIPTION
This was throwing an error to my console to the effect that module is undefined. This PR updates the export pattern so that it'll work by including the script using a script tag, and will also work with bundlers like webpack or browserify